### PR TITLE
Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.11.2] - 2023-03-20
+
+### Fixed
+
+- Typescript: added missing methods (`setValues`, `reset`) to `HTMLInformEl`.
+- When using custom elements (inform-field with a name attribute and no form element), the error was not disappearing when the value became valid.
+- The default error message now has a default top margin of 5px (unless otherwise specified by `--error-margin`).
+- Fixed a possible js error on unmount if the form element was destroyed before informel.
+- When using error slots, the slot was always shown even if the field was valid (it would be empty when valid but bg color and padding would be visible).
+
 ## [1.11.1] - 2023-03-02
 
 ### Fixed

--- a/react-src/index.d.ts
+++ b/react-src/index.d.ts
@@ -24,9 +24,11 @@ export type ValidationHandler<FormValuesType extends Record<string, unknown>> = 
 } | undefined;
 export type SubmitTransform<FormValuesType, RequestType = FormValuesType> = (param: { values: FormValuesType; }) => RequestType;
 
-export interface HTMLInformEl extends HTMLElement {
+export interface HTMLInformEl<FormValuesType extends Record<string, unknown> = Record<string, unknown>> extends HTMLElement {
     requestSubmit: () => void;
-};
+    setValues: (values: Partial<FormValuesType>) => void;
+    reset: (values?: Partial<FormValuesType>) => void;
+}
 
 export type InformElProps<FormValuesType extends Record<string, unknown> = FormValuesDefaultType, ResponseType = any, RequestType = FormValuesType> = React.PropsWithRef<{
     children?: ReactNode;

--- a/src/inform-el.svelte
+++ b/src/inform-el.svelte
@@ -401,15 +401,16 @@
             }
         });
 
-        // Look for extra fields in the validation result
-        if (normalizedValidationErrors) {
-            for (let key in normalizedValidationErrors) {
-                const informField = getInformFieldByName(key);
-                if (informField) {
-                    informField.setAttribute('error-message', normalizedValidationErrors[key]);
-                }
+        const informFieldsWithName = [...host.querySelectorAll('inform-field[name]')];
+        informFieldsWithName.forEach((informField) => {
+            const name = normalizePath(informField.getAttribute('name'));
+            const errorPropValue = normalizedValidationErrors?.[name];
+            if (errorPropValue) {
+                informField.setAttribute('error-message', errorPropValue);
+            } else {
+                informField.removeAttribute('error-message');
             }
-        }
+        });
 
         const flatExtraValues = flattenObject(extraValues);
 
@@ -518,10 +519,10 @@
         if (observer) {
             observer.disconnect();
         }
-        form.removeEventListener('change', handleChange);
-        form.removeEventListener('input', handleInput);
-        form.removeEventListener('submit', handleSubmit);
-        form.removeEventListener('reset', handleFormReset);
+        form?.removeEventListener('change', handleChange);
+        form?.removeEventListener('input', handleInput);
+        form?.removeEventListener('submit', handleSubmit);
+        form?.removeEventListener('reset', handleFormReset);
     }
 
     onMount(() => {

--- a/src/inform-field.svelte
+++ b/src/inform-field.svelte
@@ -14,6 +14,7 @@
     let submitOnChangeIsPresent;
     let touchedOnInputIsPresent;
     let errorId = 'informel-err-el-screen-reader-' + Math.random().toString(36);
+    let slotDisplayBackup;
 
     $: {
         // Update error attribute
@@ -83,6 +84,11 @@
 
         if (errorSlotChild && touchedIsPresent) {
             errorSlotChild.textContent = errorMessage;
+            if (errorMessage) {
+                errorSlotChild.style.display = slotDisplayBackup;
+            } else {
+                errorSlotChild.style.display = 'none';
+            }
         }
     }
 
@@ -90,6 +96,12 @@
         errorSlot = rootElement.querySelector('slot[name="error"]');
 
         errorSlot.addEventListener('slotchange', updateErrorSlot);
+
+        const errorSlotChild = errorSlot?.assignedElements()?.[0];
+        if (!!errorSlotChild) {
+            slotDisplayBackup = getComputedStyle(errorSlotChild).display;
+            errorSlotChild.style.display = 'none';
+        }
 
         // Generate an invisible error message for screen readers, for using with aria-describedby
         const errEl = document.createElement('span');
@@ -119,7 +131,7 @@
 <style>
     .form-field-error {
         color: var(--error-color, red);
-        margin: var(--error-margin, 0 0 0 0);
+        margin: var(--error-margin, 5px 0 0 0);
         font-size: var(--error-font-size, 1rem);
         font-family: var(--error-font-family, inherit);
         display: var(--error-display, block);

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -72,7 +72,7 @@ describe('error', () => {
             // Not touched: no error displayed
             expect(getNativeContainer(informField)).not.to.exist;
             if (slot) {
-                expect(getErrorContainer(informField)).to.have.rendered.text('');
+                expect(getErrorContainer(informField)).not.to.be.displayed;
             }
 
             // Not in format email
@@ -111,7 +111,7 @@ describe('error', () => {
             await type(input, 'some@else');
             expect(getNativeContainer(informField)).not.to.exist;
             if (slot) {
-                expect(getErrorContainer(informField)).to.have.rendered.text('');
+                expect(getErrorContainer(informField)).not.to.be.displayed;
             }
 
         }

--- a/test/setvalues.test.js
+++ b/test/setvalues.test.js
@@ -377,4 +377,39 @@ describe('set values', () => {
 
         expect(informUpdatedTriggered()).to.be.true;
     });
+
+    it('triggers validation for custom form elements', async () => {
+        const informEl = await fixture(`
+            <inform-el>
+                <form>
+                    <inform-field name="custom">
+                    </inform-field>
+                </form>
+            </inform-el>
+        `);
+
+        const informField = informEl.querySelector('inform-field');
+
+        informEl.validationHandler = ({ values }) => {
+            return { // Inverted key format compared to field names
+                'custom': values.custom === 'error' ? 'invalid value' : undefined,
+            };
+        };
+
+        // Not touched yet, not in error
+        expect(informField).not.to.have.attribute('error');
+
+        informEl.setValues({ custom: 'error' });
+
+        expect(informField.shadowRoot.getRootNode().querySelector('[role="alert"]')).to.exist;
+        expect(informField).to.have.attribute('error-message', 'invalid value');
+        expect(informField).to.have.attribute('error');
+
+        informEl.setValues({ custom: 'valid' });
+
+        expect(informField.shadowRoot.getRootNode().querySelector('[role="alert"]')).not.to.exist;
+        expect(informField).not.to.have.attribute('error-message');
+        expect(informField).not.to.have.attribute('error');
+
+    });
 });


### PR DESCRIPTION
Fixes:

- Typescript: added missing methods (`setValues`, `reset`) to `HTMLInformEl`.
- When using custom elements (inform-field with a name attribute and no form element), the error was not disappearing when the value became valid.
- The default error message now has a default top margin of 5px (unless otherwise specified by `--error-margin`).
- Fixed a possible js error on unmount if the form element was destroyed before informel.
- When using error slots, the slot was always shown even if the field was valid (it would be empty when valid but bg color and padding would be visible).